### PR TITLE
Clarified the units of width and height in the Text class

### DIFF
--- a/docs/classes/Text.html
+++ b/docs/classes/Text.html
@@ -86,11 +86,11 @@ types if that is more convenient for your application.</p>
 </div></li>
 <li>
 <h5>width: <span class="tsd-signature-type">number</span></h5>
-<div class="tsd-comment tsd-typography"><p>The width of the text canvas</p>
+<div class="tsd-comment tsd-typography"><p>The width of the text canvas (in pixels)</p>
 </div></li>
 <li>
 <h5>height: <span class="tsd-signature-type">number</span></h5>
-<div class="tsd-comment tsd-typography"><p>The height of the text canvas</p>
+<div class="tsd-comment tsd-typography"><p>The height of the text canvas (in pixels)</p>
 </div></li>
 <li>
 <h5>font: <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = &#39;24px monospace&#39;</span></h5>

--- a/src/materials/Text.ts
+++ b/src/materials/Text.ts
@@ -25,8 +25,8 @@ export class Text extends Texture
  * types if that is more convenient for your application.
  * 
  * @param text - The text to be rendered
- * @param width - The width of the text canvas
- * @param height - The height of the text canvas
+ * @param width - The width of the text canvas (in pixels)
+ * @param height - The height of the text canvas (in pixels)
  * @param font - The font style of the text. Can be a gfx.Color or see additional options for
  * [canvas.font](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/font).
  * @param fillStyle - The fill style of the text. Can be a gfx.Color or see additional options for


### PR DESCRIPTION
Many students were interpreting width and height as lengths in the normalized device coordinate plane, so I added the actual unit to the descriptions of these parameters.