### PR TITLE
feat: allow method chaining on vectors

### DIFF
--- a/src/math/Vector2.ts
+++ b/src/math/Vector2.ts
@@ -472,7 +472,7 @@ export class Vector2
         
         // zero vectors
         if(sizeSquared < 1e-8)
-            return;
+            return this;
 
         const scaleFactor = 1 / Math.sqrt(sizeSquared);
         this.x *= scaleFactor;

--- a/src/math/Vector2.ts
+++ b/src/math/Vector2.ts
@@ -252,10 +252,12 @@ export class Vector2
      * @param x - The new x coordinate of the Vector2
      * @param y - The new y coordinate of the Vector2
      */
-    set(x: number, y: number): void
+    set(x: number, y: number)
     {
         this.x = x;
         this.y = y;
+
+        return this;
     }
 
     /**
@@ -263,10 +265,12 @@ export class Vector2
      * 
      * @param v - The Vector2 object to copy
      */
-    copy(v: Vector2): void
+    copy(v: Vector2)
     {
         this.x = v.x;
         this.y = v.y;
+
+        return this;
     }
 
     /**
@@ -295,10 +299,12 @@ export class Vector2
      * 
      * @param v - The Vector2 to add to this Vector2
      */
-    add(v: Vector2): void
+    add(v: Vector2)
     {
         this.x += v.x;
         this.y += v.y;
+
+        return this;
     }
 
     /**
@@ -306,10 +312,12 @@ export class Vector2
      * 
      * @param v - The Vector2 to subtract from this Vector2
      */
-    subtract(v: Vector2): void
+    subtract(v: Vector2)
     {
         this.x -= v.x;
         this.y -= v.y;
+
+        return this;
     }
 
     /**
@@ -317,10 +325,12 @@ export class Vector2
      * 
      * @param v - The Vector2 to multiply this Vector2 by
      */
-    multiply(v: Vector2): void
+    multiply(v: Vector2)
     {
         this.x *= v.x;
         this.y *= v.y;
+
+        return this;
     }
 
     /**
@@ -328,10 +338,12 @@ export class Vector2
      * 
      * @param v - The Vector2 to divide this Vector2 by
      */
-    divide(v: Vector2): void
+    divide(v: Vector2)
     {
         this.x /= v.x;
         this.y /= v.y;
+
+        return this;
     }
 
     /**
@@ -339,10 +351,12 @@ export class Vector2
      * 
      * @param n - The scalar value to multiply by
      */
-    multiplyScalar(n: number): void
+    multiplyScalar(n: number)
     {
         this.x *= n;
         this.y *= n;
+
+        return this;
     }
 
     /**
@@ -350,10 +364,12 @@ export class Vector2
      * 
      * @param n - The scalar value to divide by
      */
-    divideScalar(n: number): void
+    divideScalar(n: number)
     {
         this.x /= n;
         this.y /= n;
+
+        return this;
     }
 
     /**
@@ -375,10 +391,12 @@ export class Vector2
      * 
      * @param m - The Matrix3 to get the position from
      */
-    setPositionFromMatrix(m: Matrix3): void
+    setPositionFromMatrix(m: Matrix3)
     {
         this.x = m.mat[6];
         this.y = m.mat[7];
+
+        return this;
     }
 
     /**
@@ -386,10 +404,12 @@ export class Vector2
      * 
      * @param m - The Matrix3 to get the scale from
      */
-    setScaleFromMatrix(m: Matrix3): void
+    setScaleFromMatrix(m: Matrix3)
     {
         this.x = Math.sqrt(m.mat[0]*m.mat[0] + m.mat[1]*m.mat[1]);
         this.y = Math.sqrt(m.mat[3]*m.mat[3] + m.mat[4]*m.mat[4]);
+
+        return this;
     }
 
     /**
@@ -397,12 +417,14 @@ export class Vector2
      * 
      * @param m - The Matrix3 to transform this Vector2 with
      */
-    transformPoint(m: Matrix3): void
+    transformPoint(m: Matrix3)
     {
         const v = this.clone();
         const w = 1 / (m.mat[2]*v.x + m.mat[5]*v.y + m.mat[8]);
         this.x = w * (m.mat[0]*v.x + m.mat[3]*v.y + m.mat[6]);
         this.y = w * (m.mat[1]*v.x + m.mat[4]*v.y + m.mat[7]);
+
+        return this;
     }
 
     /**
@@ -410,12 +432,14 @@ export class Vector2
      * 
      * @param m - The Matrix3 to transform this Vector2 with
      */
-    transformVector(m: Matrix3): void
+    transformVector(m: Matrix3)
     {
         const v = this.clone();
         const w = 1 / (m.mat[2]*v.x + m.mat[5]*v.y + m.mat[8]);
         this.x = w * (m.mat[0]*v.x + m.mat[3]*v.y);
         this.y = w * (m.mat[1]*v.x + m.mat[4]*v.y);
+
+        return this;
     }
 
     /**
@@ -442,7 +466,7 @@ export class Vector2
     /**
      * Normalizes this Vector2
      */
-    normalize(): void
+    normalize()
     {
         const sizeSquared = this.x*this.x + this.y*this.y;
         
@@ -453,15 +477,19 @@ export class Vector2
         const scaleFactor = 1 / Math.sqrt(sizeSquared);
         this.x *= scaleFactor;
         this.y *= scaleFactor;
+
+        return this;
     }
 
     /**
      * Inverts this Vector2
      */
-    invert(): void
+    invert()
     {
         this.x = -this.x;
         this.y = -this.y;
+
+        return this;
     }
 
     /**
@@ -497,12 +525,14 @@ export class Vector2
      * 
      * @param angle - The angle to rotate by in radians
      */
-    rotate(angle: number): void
+    rotate(angle: number)
     {
         const x = this.x;
         const y = this.y;
         this.x = Math.cos(angle)*x - Math.sin(angle)*y;
         this.y = Math.sin(angle)*x + Math.cos(angle)*y; 
+
+        return this;
     }
 
     /**
@@ -512,9 +542,11 @@ export class Vector2
      * @param v2 - The second Vector2 object
      * @param alpha - The interpolation value between 0 and 1
      */
-    lerp(v1: Vector2, v2: Vector2, alpha: number): void
+    lerp(v1: Vector2, v2: Vector2, alpha: number)
     {
         this.x = v1.x * (1-alpha) + v2.x * alpha;
         this.y = v1.y * (1-alpha) + v2.y * alpha;
+
+        return this;
     }
 }

--- a/src/math/Vector3.ts
+++ b/src/math/Vector3.ts
@@ -596,7 +596,7 @@ export class Vector3
         
         // zero vectors
         if(sizeSquared < 1e-8)
-            return;
+            return this;
 
         const scaleFactor = 1 / Math.sqrt(sizeSquared);
         this.x *= scaleFactor;

--- a/src/math/Vector3.ts
+++ b/src/math/Vector3.ts
@@ -407,11 +407,13 @@ export class Vector3
      * @param y - The y value to set
      * @param z - The z value to set
      */
-    set(x: number, y: number, z: number): void
+    set(x: number, y: number, z: number)
     {
         this.x = x;
         this.y = y;
         this.z = z;
+
+        return this;
     }
 
     /**
@@ -419,11 +421,13 @@ export class Vector3
      *
      * @param v - The Vector3 object to copy
      */
-    copy(v: Vector3): void
+    copy(v: Vector3)
     {
         this.x = v.x;
         this.y = v.y;
         this.z = v.z;
+
+        return this;
     }
 
     /**
@@ -465,11 +469,13 @@ export class Vector3
      *
      * @param v - The Vector3 object to add
      */
-    add(v: Vector3): void
+    add(v: Vector3)
     {
         this.x += v.x;
         this.y += v.y;
         this.z += v.z;
+
+        return this;
     }
 
     /**
@@ -477,11 +483,13 @@ export class Vector3
      *
      * @param v - The Vector3 object to subtract
      */
-    subtract(v: Vector3): void
+    subtract(v: Vector3)
     {
         this.x -= v.x;
         this.y -= v.y;
         this.z -= v.z;
+
+        return this;
     }
 
     /**
@@ -489,11 +497,13 @@ export class Vector3
      *
      * @param v - The Vector3 object to multiply
      */
-    multiply(v: Vector3): void
+    multiply(v: Vector3)
     {
         this.x *= v.x;
         this.y *= v.y;
         this.z *= v.z;
+
+        return this;
     }
 
     /**
@@ -501,11 +511,13 @@ export class Vector3
      *
      * @param v - Vector to divide with
      */
-    divide(v: Vector3): void
+    divide(v: Vector3)
     {
         this.x /= v.x;
         this.y /= v.y;
         this.z /= v.z;
+
+        return this;
     }
 
     /**
@@ -524,7 +536,7 @@ export class Vector3
      *
      * @param v The Vector3 to compute the cross product with.
      */
-    cross(v: Vector3): void
+    cross(v: Vector3)
     {
         const crossProduct =  new Vector3(
             this.y * v.z - this.z * v.y,
@@ -532,6 +544,8 @@ export class Vector3
             this.x * v.y - this.y * v.x
         );
         this.copy(crossProduct);
+
+        return this;
     }
 
     /**
@@ -539,11 +553,13 @@ export class Vector3
      *
      * @param n - Scalar value to multiply with
      */
-    multiplyScalar(n: number): void
+    multiplyScalar(n: number)
     {
         this.x *= n;
         this.y *= n;
         this.z *= n;
+
+        return this;
     }
 
     /**
@@ -551,11 +567,13 @@ export class Vector3
      *
      * @param n - Scalar value to divide with
      */
-    divideScalar(n: number): void
+    divideScalar(n: number)
     {
         this.x /= n;
         this.y /= n;
         this.z /= n;
+
+        return this;
     }
 
     /**
@@ -572,7 +590,7 @@ export class Vector3
      * Normalizes a Vector3 object
      *
      */
-    normalize(): void
+    normalize()
     {
         const sizeSquared = this.x*this.x + this.y*this.y + this.z*this.z;
         
@@ -584,17 +602,21 @@ export class Vector3
         this.x *= scaleFactor;
         this.y *= scaleFactor;
         this.z *= scaleFactor;
+
+        return this;
     }
 
     /**
      * Inverts a Vector3 object
      *
      */
-    invert(): void
+    invert()
     {
         this.x = -this.x;
         this.y = -this.y;
         this.z = -this.z;
+
+        return this;
     }
 
     /**
@@ -612,13 +634,15 @@ export class Vector3
      *
      * @param m - The Matrix4 to transform this Vector3
      */
-    transformPoint(m: Matrix4): void
+    transformPoint(m: Matrix4)
     {
         const v = this.clone();
         const w = 1 / (m.mat[3]*v.x + m.mat[7]*v.y + m.mat[11]*v.z + m.mat[15]);
         this.x = w * (m.mat[0]*v.x + m.mat[4]*v.y + m.mat[8]*v.z + m.mat[12]);
         this.y = w * (m.mat[1]*v.x + m.mat[5]*v.y + m.mat[9]*v.z + m.mat[13]);
         this.z = w * (m.mat[2]*v.x + m.mat[6]*v.y + m.mat[10]*v.z + m.mat[14]);
+
+        return this;
     }
 
     /**
@@ -626,13 +650,15 @@ export class Vector3
      *
      * @param m - The Matrix4 to transform this Vector3
      */
-    transformVector(m: Matrix4): void
+    transformVector(m: Matrix4)
     {
         const v = this.clone();
         const w = 1 / (m.mat[3]*v.x + m.mat[7]*v.y + m.mat[11]*v.z + m.mat[15]);
         this.x = w * (m.mat[0]*v.x + m.mat[4]*v.y + m.mat[8]*v.z);
         this.y = w * (m.mat[1]*v.x + m.mat[5]*v.y + m.mat[9]*v.z);
         this.z = w * (m.mat[2]*v.x + m.mat[6]*v.y + m.mat[10]*v.z);
+
+        return this;
     }
 
     /**
@@ -640,7 +666,7 @@ export class Vector3
      *
      * @param q - The Quaternion to rotate this Vector3
      */
-    rotate(q: Quaternion): void
+    rotate(q: Quaternion)
     {
         // Extract the vector part of the quaternion
         const u = new Vector3(q.x, q.y, q.z);
@@ -656,6 +682,8 @@ export class Vector3
         result.add(crossUV);
 
         this.copy(result);
+
+        return this;
     }
 
     /**
@@ -692,11 +720,13 @@ export class Vector3
      *
      * @param m - The Matrix4 to get the position from
      */
-    setPositionFromMatrix(m: Matrix4): void
+    setPositionFromMatrix(m: Matrix4)
     {
         this.x = m.mat[12];
         this.y = m.mat[13];
         this.z = m.mat[14];
+
+        return this;
     }
 
     /**
@@ -704,11 +734,13 @@ export class Vector3
      *
      * @param m - The Matrix4 to get the scale from
      */
-    setScaleFromMatrix(m: Matrix4): void
+    setScaleFromMatrix(m: Matrix4)
     {
         this.x = Math.sqrt(m.mat[0]*m.mat[0] + m.mat[1]*m.mat[1] + m.mat[2]*m.mat[2]);
         this.y = Math.sqrt(m.mat[4]*m.mat[4] + m.mat[5]*m.mat[5] + m.mat[6]*m.mat[6]);
         this.z = Math.sqrt(m.mat[8]*m.mat[8] + m.mat[9]*m.mat[9] + m.mat[10]*m.mat[10]);
+
+        return this;
     }
 
     /**
@@ -718,11 +750,13 @@ export class Vector3
      * @param v2 - The ending Vector3
      * @param alpha - The interpolation amount (should be in the range [0, 1])
      */
-    lerp(v1: Vector3, v2: Vector3, alpha: number): void
+    lerp(v1: Vector3, v2: Vector3, alpha: number)
     {
         this.x = v1.x * (1-alpha) + v2.x * alpha;
         this.y = v1.y * (1-alpha) + v2.y * alpha;
         this.z = v1.z * (1-alpha) + v2.z * alpha;
+
+        return this;
     }
 
     /**
@@ -730,11 +764,13 @@ export class Vector3
      *
      * @param n - The normal to reflect about
      */
-    reflect(normal: Vector3): void
+    reflect(normal: Vector3)
     {
         const reflection = normal.clone();
         reflection.multiplyScalar(this.dot(normal) * -2);
         reflection.add(this);
         this.copy(reflection);
+
+        return this;
     }
 }


### PR DESCRIPTION
This pull request updates the `Vector2` and `Vector3` classes in the `src/math` directory to make their methods chainable. Instead of returning `void`, most mutating methods now return `this`, allowing for method chaining and more concise code.

The most important changes are:

**Vector2 class improvements (`src/math/Vector2.ts`):**

* All mutating methods (e.g., `set`, `copy`, `add`, `subtract`, `multiply`, `divide`, `multiplyScalar`, `divideScalar`, `setPositionFromMatrix`, `setScaleFromMatrix`, `transformPoint`, `transformVector`, `normalize`, `invert`, `rotate`, `lerp`) now return `this` instead of `void`, enabling method chaining. [[1]](diffhunk://#diff-cae3c9878919bbceaa0057b7d7c824f512108a73c2a215b5a968c1af096aea66L255-R273) [[2]](diffhunk://#diff-cae3c9878919bbceaa0057b7d7c824f512108a73c2a215b5a968c1af096aea66L298-R372) [[3]](diffhunk://#diff-cae3c9878919bbceaa0057b7d7c824f512108a73c2a215b5a968c1af096aea66L378-R442) [[4]](diffhunk://#diff-cae3c9878919bbceaa0057b7d7c824f512108a73c2a215b5a968c1af096aea66L445-R469) [[5]](diffhunk://#diff-cae3c9878919bbceaa0057b7d7c824f512108a73c2a215b5a968c1af096aea66R480-R492) [[6]](diffhunk://#diff-cae3c9878919bbceaa0057b7d7c824f512108a73c2a215b5a968c1af096aea66L500-R535) [[7]](diffhunk://#diff-cae3c9878919bbceaa0057b7d7c824f512108a73c2a215b5a968c1af096aea66L515-R550)

**Vector3 class improvements (`src/math/Vector3.ts`):**

* All mutating methods (e.g., `set`, `copy`, `add`, `subtract`, `multiply`, `divide`, `cross`, `multiplyScalar`, `divideScalar`, `normalize`, `invert`, `transformPoint`, `transformVector`, `rotate`, `setPositionFromMatrix`, `setScaleFromMatrix`, `lerp`, `reflect`) now return `this` instead of `void`, enabling method chaining. [[1]](diffhunk://#diff-064725059072250d79bdb9f6e2c2979f946b17d7f213600c3701793a386c3546L410-R430) [[2]](diffhunk://#diff-064725059072250d79bdb9f6e2c2979f946b17d7f213600c3701793a386c3546L468-R520) [[3]](diffhunk://#diff-064725059072250d79bdb9f6e2c2979f946b17d7f213600c3701793a386c3546L527-R576) [[4]](diffhunk://#diff-064725059072250d79bdb9f6e2c2979f946b17d7f213600c3701793a386c3546L575-R593) [[5]](diffhunk://#diff-064725059072250d79bdb9f6e2c2979f946b17d7f213600c3701793a386c3546R605-R619) [[6]](diffhunk://#diff-064725059072250d79bdb9f6e2c2979f946b17d7f213600c3701793a386c3546L615-R669) [[7]](diffhunk://#diff-064725059072250d79bdb9f6e2c2979f946b17d7f213600c3701793a386c3546R685-R686) [[8]](diffhunk://#diff-064725059072250d79bdb9f6e2c2979f946b17d7f213600c3701793a386c3546L695-R743) [[9]](diffhunk://#diff-064725059072250d79bdb9f6e2c2979f946b17d7f213600c3701793a386c3546L721-R774)

These changes make the API more ergonomic and consistent with common JavaScript and TypeScript practices.